### PR TITLE
Correct deprecated expressions.

### DIFF
--- a/dygraphs-gwt-sample/pom.xml
+++ b/dygraphs-gwt-sample/pom.xml
@@ -27,7 +27,7 @@
         <version>0.12</version>
         <configuration>
           <message>Creating site for ${project.version}</message>
-          <outputDirectory>${project.build.directory}/${artifactId}-${version}/${gwt.shortName}</outputDirectory>
+          <outputDirectory>${project.build.directory}/${project.artifactId}-${project.version}/${gwt.shortName}</outputDirectory>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
${artifactId} and ${version} are deprecated.
